### PR TITLE
Permetezo waypoint shift

### DIFF
--- a/ArduCopter/version.h
+++ b/ArduCopter/version.h
@@ -6,7 +6,7 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduCopter V4.3.6"
+#define THISFIRMWARE "ArduCopter V4.3.6-4IG"
 
 // the following line is parsed by the autotest scripts
 #define FIRMWARE_VERSION 4,3,6,FIRMWARE_VERSION_TYPE_OFFICIAL

--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -309,7 +309,7 @@ bool AC_WPNav::set_wp_destination(const Vector3f& destination, bool terrain_alt)
     float origin_speed = 0.0f;
 
     // use previous destination as origin
-    _origin = _destination;
+    _origin = _destination_zeroed;
 
     if (terrain_alt == _terrain_alt) {
         if (_this_leg_is_spline) {
@@ -348,7 +348,7 @@ bool AC_WPNav::set_wp_destination(const Vector3f& destination, bool terrain_alt)
     _origin_zeroed = _origin;
     _destination_zeroed = destination;
 
-
+   
     //Add shift 
     _origin.x = _origin.x + _shift_x;
     _origin.y = _origin.y + _shift_y;
@@ -393,7 +393,7 @@ bool AC_WPNav::set_wp_destination_next(const Vector3f& destination, bool terrain
         new_destination = destination;
         new_destination.x = destination.x + _shift_x;
         new_destination.y = destination.y + _shift_y;
-
+    
     _scurve_next_leg.calculate_track(_destination, new_destination,
                                      _pos_control.get_max_speed_xy_cms(), _pos_control.get_max_speed_up_cms(), _pos_control.get_max_speed_down_cms(),
                                      get_wp_acceleration(), _wp_accel_z_cmss,
@@ -618,17 +618,19 @@ bool AC_WPNav::update_wpnav()
     bool ret = true;
 
     //Perhaps it does not belong here, but let's check if we can get along with it.
-
-
-
+    
+    
+    
     //Check if there are changes in the shift vectors
-    if ((abs(_last_shift_x - _shift_x) <  1) || (abs(_last_shift_y - _shift_x) < 1))
+    if (((int)_last_shift_x != (int)_shift_x) || ((int)_last_shift_y != (int)_shift_y))
     {
         _destination.x = _destination_zeroed.x + _shift_x;
         _destination.y = _destination_zeroed.y + _shift_y;
 
         _origin.x = _origin_zeroed.x + _shift_x;
         _origin.y = _origin_zeroed.y + _shift_y;
+
+        gcs().send_text(MAV_SEVERITY_INFO, "New Shift : X %i -> %i, Y %i -> %i",(int)_last_shift_x, (int)_shift_x, (int)_last_shift_y, (int)_shift_y);
 
         _last_shift_x = _shift_x;
         _last_shift_y = _shift_y;

--- a/libraries/AC_WPNav/AC_WPNav.h
+++ b/libraries/AC_WPNav/AC_WPNav.h
@@ -278,4 +278,16 @@ protected:
     AP_Int8     _rangefinder_use;       // parameter that specifies if the range finder should be used for terrain following commands
     bool        _rangefinder_healthy;   // true if rangefinder distance is healthy (i.e. between min and maximum)
     float       _rangefinder_alt_cm;    // latest distance from the rangefinder
+
+    
+    AP_Float       _shift_x;       //Shift current wp origin and destination by x cm on X direction
+    AP_Float       _shift_y;       //shift current wp origin and destination by x cm on Y direction
+
+
+    AP_Float       _last_shift_x;   //Temporary storage for detect cahnges in x and y
+    AP_Float       _last_shift_y;
+
+    Vector3f       _destination_zeroed; // Save of the original destination
+    Vector3f       _origin_zeroed;      // Save of the original origin
+
 };


### PR DESCRIPTION
Add's WPNAV_SHIFT_X and WPNAV_SHIFT_Y to the parameters list, where you can add route shift in centimeters. Positive east and north.
Make sure that if the copter is not in auto mode, set those values to zero, to avoid issues with home point location.
Also Disable OA, OA will not work with shifts.
